### PR TITLE
Fix typo in parse_four_letter_word fn

### DIFF
--- a/docs/string/parser/index.html
+++ b/docs/string/parser/index.html
@@ -626,7 +626,7 @@ instead.</p>
  pub fn example () {
      let is_not_space = fn (c) { c != &quot; &quot; }
      let parse_four_letter_word = fn (s) {
-         case string.length(s) {
+         case string.length(s) == 4 {
              True -&gt; 
                  parser.succeed(s)
 
@@ -679,7 +679,7 @@ type here.</p>
  pub fn example () {
      let is_not_space = fn (c) { c != &quot; &quot; }
      let parse_four_letter_word = fn (s) {
-         case string.length(s) {
+         case string.length(s) == 4 {
              True -&gt; 
                  parser.succeed(s)
 

--- a/docs/string/parser/index.html
+++ b/docs/string/parser/index.html
@@ -626,7 +626,7 @@ instead.</p>
  pub fn example () {
      let is_not_space = fn (c) { c != &quot; &quot; }
      let parse_four_letter_word = fn (s) {
-         case string.length(s) == 4 {
+         case string.length(s) {
              True -&gt; 
                  parser.succeed(s)
 
@@ -679,7 +679,7 @@ type here.</p>
  pub fn example () {
      let is_not_space = fn (c) { c != &quot; &quot; }
      let parse_four_letter_word = fn (s) {
-         case string.length(s) == 4 {
+         case string.length(s) {
              True -&gt; 
                  parser.succeed(s)
 

--- a/src/string/parser.gleam
+++ b/src/string/parser.gleam
@@ -305,7 +305,7 @@ pub fn succeed4 (f: fn (a, b, c, d) -> e) -> Parser(fn (a) -> fn (b) -> fn (c) -
 ///     pub fn example () {
 ///         let is_not_space = fn (c) { c != " " }
 ///         let parse_four_letter_word = fn (s) {
-///             case string.length(s) {
+///             case string.length(s) == 4 {
 ///                 True -> 
 ///                     parser.succeed(s)
 ///
@@ -354,7 +354,7 @@ pub fn fail (message: String) -> Parser(a) {
 ///     pub fn example () {
 ///         let is_not_space = fn (c) { c != " " }
 ///         let parse_four_letter_word = fn (s) {
-///             case string.length(s) {
+///             case string.length(s) == 4 {
 ///                 True -> 
 ///                     parser.succeed(s)
 ///


### PR DESCRIPTION
Missing `== 4` check.