### PR TITLE
Make it go fast (I think?)

### DIFF
--- a/src/string/parser.gleam
+++ b/src/string/parser.gleam
@@ -512,14 +512,12 @@ pub fn eof() -> Parser(Nil) {
 /// </div>
 ///
 pub fn string(value: String) -> Parser(String) {
-  let length = string.length(value)
   let expect = string.concat(["A string that starts with '", value, "'"])
 
   Parser(fn(input) {
-    case string.starts_with(input, value) {
-      True -> Ok(#(value, string.drop_left(input, length)))
-
-      False -> Error(Expected(expect, got: input))
+    case string.split_once(input, value) {
+      Ok(#("", rest)) -> Ok(#(input, rest))
+      _ -> Error(Expected(expect, got: input))
     }
   })
 }


### PR DESCRIPTION
This seems to work and the tests pass, but my brain isn't working this evening so please don't take my word for it.

I tried using an Erlang library called `fprof` to profile what was taking so much time, and it seemed to suggest that the `parser.string` function was the culprit. 

I may be wrong, but when I looked into the implementation, it seems like the `string.drop_left` function from the `stdlib` is very slow for some reason.